### PR TITLE
[24755] Election Paradox 해결

### DIFF
--- a/src/main/java/baekjoon/silver/BaekJoon24755.java
+++ b/src/main/java/baekjoon/silver/BaekJoon24755.java
@@ -1,0 +1,54 @@
+package baekjoon.silver;
+
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+/*
+Election Paradox
+ */
+public class BaekJoon24755 {
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+    public static void main(String[] args) throws IOException {
+        int[] person=init();
+
+        input(person);
+
+        Arrays.sort(person);
+
+        int count = 0;
+
+        int canLose = person.length/2 +1;
+        for(int i = canLose;i<person.length;i++){
+             count += person[i];
+        }
+
+        for(int i = 0 ; i <canLose;i++){
+            count += person[i]/2;
+        }
+
+        System.out.print(count);
+
+    }
+
+    private static int[] init() throws IOException {
+
+        int town = Integer.parseInt(br.readLine());
+
+        return new int[town];
+    }
+
+    private static void input(int[] person) throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine()," ");
+
+        int i = 0;
+        while(st.hasMoreTokens()){
+            person[i++] = Integer.parseInt(st.nextToken());
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ 어떤 브랜치인가요?
- [ ] basic
- [x] baekjoon
- [ ] other: <!-- 브랜치 이름 직접 작성 -->

---

## 📝 문제 설명 (Describe)

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요.
     어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- **문제 번호**:24755
- **문제 이름**: Election Paradox
- **문제 설명 (스크린샷 첨부 가능)**:

<details>
<summary>📷 문제 원문/설명 보기</summary>

<!-- 문제 스크린샷 또는 요약 설명 첨부 -->
특정 나라에 홀수 개의 마을에 홀수 명의 사람이 살며 해당 나라에서는 대통령을
각 마을마다 득표 수가 많은 사람을 대표로 지정을 하게 됨.

이때 패배팀에서 받을 수 있는 최대 개수의 득표수를 구하시오.



</details>

---

## 📚 입출력 예제

<!-- 테스트 케이스나 예제 등을 첨부해주세요 -->

<details>
<summary>🧪 예제 보기</summary>

<!-- 입출력 스크린샷 혹은 복사본 -->

</details>

---

## 🛠️ 어떻게 풀었나요? (풀이 전략)

<!-- 어떤 알고리즘을 썼는지, 시간복잡도나 핵심 아이디어 위주로 작성해주세요 -->
- 사용 알고리즘: 그리디 알고리즘
- 시간복잡도 분석: O(n log n)
- 핵심 아이디어 요약: 각 마을별 사람을 오름차순으로 정리하고 져도 되는 마을에는 전체를 count 이겨야되는 마을은 /2 만 count 하는 방식.

---

## ✅ 기타 코멘트 (선택)

<!-- 어려웠던 점이나, 질문, 혹은 토론하고 싶은 포인트 등을 적어보세요 -->