### PR TITLE
[FIX] class 찾지 못하던 문제 해결

### DIFF
--- a/algorithm.iml
+++ b/algorithm.iml
@@ -3,7 +3,7 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/src/baekjoon/class4/BaekJoon1918.java
+++ b/src/baekjoon/class4/BaekJoon1918.java
@@ -6,7 +6,6 @@ import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Stack;
-import java.util.StringTokenizer;
 
 public class BaekJoon1918 {
     static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));


### PR DESCRIPTION
## #️⃣ 어떤 브랜치인가요?
- [ ] basic
- [x] baekjoon
- [ ] other: <!-- 브랜치 이름 직접 작성 -->

---

## 📝 문제 설명 (Describe)

Gradle -> 일반 자바 프로젝트로 변경하면서 클래스를 실행할 경우 
<img width="1714" height="85" alt="image" src="https://github.com/user-attachments/assets/0344a6b8-a74f-4ee9-b610-13f44ce95dd8" />
class를 찾지 못하여 오류가 나는 상황 발생

## 문제 해결 과정

### 1. 문제 원인 찾기
해당 문제의 경우 크게 2가지 요인이 원인일 수 있다고 검색하였습니다.
첫 번째가 패키지 구조나 파일 위치의 문제
두 번째가 IntelliJ 설정 문제이었으며

이는 IntelliJ 가 아닌 터미널을 통해 .java를 컴파일, 실행해보는 과정을 거치면 구분할 수 있기에 
한번 터미널에서 컴파일, 실행해보았습니다.
<hr>

### 1-1. compile 첫 번째 시도
**명령어  javac baekjoon\class4\BaekJoon1918.java**

**[결과]**
<img width="1073" height="273" alt="image" src="https://github.com/user-attachments/assets/38839ef4-3ef4-4c52-bfdd-b3de903d2146" />

**[문제 원인]**
파일은 정상적으로 찾아지지만 encoding 기법이  x-windows-949 였고, 해당 기법은 한글을 허용하지 않아 문제가 발생.
사실 해당 부분만 봐도 패키지 구조나 파일 위치 문제가 아님을 알 수 있습니다.

<hr>

### 1-2. compile 두 번째 시도
**명령어 javac -encoding UTF-8 baekjoon/class4/BaekJoon1918.java**
<img width="1284" height="633" alt="image" src="https://github.com/user-attachments/assets/1cb96bd4-8169-4e32-8b63-37f9c428929a" />

**[결과]**
정상적으로 compile 됨을 확인
<hr>

### 1-3. 프로그램 실행
**명령어 java .  baekjoon/class4/BaekJoon1918.java**

<img width="1126" height="74" alt="image" src="https://github.com/user-attachments/assets/3e9bbdfb-dfd0-4b10-81b0-5956a46a2f38" />

**[결과]**
정상적으로 실행되는 것을 확인함으로써 IntelliJ 설정과 관련하여 문제가 발생했음을 인지 할 수 있었습니다.

<hr>

### 2. IntelliJ 문제 찾기

### 2-1. 모듈 재설정
프로젝트 실행과 관련된 모듈을 재설정 시도를 진행

algoritm 프로젝트 모듈을 삭제 이후 다시 설정한 후 빌드를 진행

**[결과]**
<img width="448" height="181" alt="image" src="https://github.com/user-attachments/assets/59f237ec-35f8-4c27-b017-96e6767a8ebf" />

**[문제 원인]**
해당 문제의 경우 왜인지 모르겠으나 프로젝트 모듈을 전부 날려버리는 과정에서 
**프로젝트 기본 출력 경로**가 사라졌음을 확인

<img width="1233" height="543" alt="image" src="https://github.com/user-attachments/assets/dd5aea66-f35a-4514-8832-947c08eb102b" />

실제 모듈(file -> 프로젝트 구조 -> 모듈 -> 경로) 에서는 **프로젝트 컴파일 출력 경로를 상속**하기로 했는데

<img width="1087" height="583" alt="image" src="https://github.com/user-attachments/assets/5d362184-8058-45b3-b4bb-671a1e5a81a8" />

해당 값이 Null이니 문제 발생. 그로인해 빌드가 진행되지 않았던 것.

새로운 프로젝트를 생성하고 자동으로 생성된 프로젝트 출력 값을 참고하여 본 프로젝트에 적용

<img width="901" height="344" alt="image" src="https://github.com/user-attachments/assets/c692a6e4-6b53-4588-b7d9-cdb6ebc662f0" />

이렇게 하니 IntelliJ 를 통해 정상적으로 실행이 됨을 확인.

<img width="1700" height="758" alt="image" src="https://github.com/user-attachments/assets/3ce58dc5-8d4c-47e7-af55-20eca4154ea6" />

# 해결

## P.S 프로젝트 설정을 바꿀 때는 해당 변경이 어디까지 전파되는 지를 잘 파악하면 좋을 것 같습니다.
